### PR TITLE
Bug squashing

### DIFF
--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -97,7 +97,7 @@ contract ContinuousToken is ERC20Token {
     function withdraw(uint256 _amountToWithdraw) returns (bool) {
         if(balances[msg.sender] >= _amountToWithdraw) {
             //determine how much you can leave with.
-            uint256 reward = _amountToWithdraw/totalSupply * poolBalance; //rounding?
+            uint256 reward = _amountToWithdraw * poolBalance/totalSupply; //rounding?
             msg.sender.transfer(reward);
             balances[msg.sender] -= _amountToWithdraw;
             totalSupply -= _amountToWithdraw;

--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -96,7 +96,7 @@ contract ContinuousToken is ERC20Token {
     }
 
     function withdraw(uint256 _amountToWithdraw) returns (bool) {
-        if(balances[msg.sender] >= _amountToWithdraw) {
+        if(_amountToWithdraw != 0 && balances[msg.sender] >= _amountToWithdraw) {
             //determine how much you can leave with.
             uint256 reward = _amountToWithdraw * poolBalance/totalSupply; //rounding?
             msg.sender.transfer(reward);

--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -95,7 +95,7 @@ contract ContinuousToken is ERC20Token {
     }
 
     function withdraw(uint256 _amountToWithdraw) returns (bool) {
-        if(balances[msg.sender] > _amountToWithdraw) {
+        if(balances[msg.sender] >= _amountToWithdraw) {
             //determine how much you can leave with.
             uint256 reward = _amountToWithdraw/totalSupply * poolBalance; //rounding?
             msg.sender.transfer(reward);

--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -95,7 +95,7 @@ contract ContinuousToken is ERC20Token {
     }
 
     function withdraw(uint256 _amountToWithdraw) returns (bool) {
-        if(balances[msg.sender] - _amountToWithdraw > 0) {
+        if(balances[msg.sender] > _amountToWithdraw) {
             //determine how much you can leave with.
             uint256 reward = _amountToWithdraw/totalSupply * poolBalance; //rounding?
             msg.sender.transfer(reward);

--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -104,6 +104,9 @@ contract ContinuousToken is ERC20Token {
             totalSupply -= _amountToWithdraw;
             updateCostOfToken(totalSupply);
             LogWithdraw(_amountToWithdraw, reward);
+            return true;
+        } else {
+            throw;
         }
     }
 
@@ -138,6 +141,9 @@ contract CurationToken is ContinuousToken {
             totalBonded += _amount;
             totalBondsPerCuratorPerSubtopic[_curator][_subtopic] += _amount;
             LogBond(msg.sender, _curator, _subtopic, _amount);
+            return true;
+        } else {
+            return false;
         }
     }
 
@@ -148,6 +154,9 @@ contract CurationToken is ContinuousToken {
             totalBonded -= _amount;
             totalBondsPerCuratorPerSubtopic[_curator][_subtopic] -= _amount;
             LogWithdrawBond(msg.sender, _curator, _subtopic, _amount);
+            return true;
+        } else {
+            return false;
         }
     }
 

--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -15,6 +15,8 @@ This can be re-used without the bonding functionality.
 */
 contract ContinuousToken is ERC20Token {
 
+    uint public constant MAX_UINT = (2**256) - 1;
+
     uint256 baseCost = 100000000000000; //100000000000000 wei 0.0001 ether
     uint256 public costPerToken = 0;
 
@@ -63,7 +65,7 @@ contract ContinuousToken is ERC20Token {
     function mint(uint256 _amountToMint) payable returns (bool) {
         //balance of msg.sender increases if paid right amount according to protocol
 
-        if(_amountToMint > 0 && msg.value > 0) {
+        if(_amountToMint > 0 && (MAX_UINT - _amountToMint) >= totalSupply && msg.value > 0) {
 
             uint256 totalMinted = 0;
             uint256 totalCost = 0;

--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -84,6 +84,7 @@ contract ContinuousToken is ERC20Token {
 
             totalEverMinted += totalMinted;
             totalSupply += totalMinted;
+            balances[msg.sender] += totalMinted;
             poolBalance += totalCost;
 
             LogMint(totalMinted, totalCost);

--- a/CurationMarkets.sol
+++ b/CurationMarkets.sol
@@ -98,7 +98,7 @@ contract ContinuousToken is ERC20Token {
     }
 
     function withdraw(uint256 _amountToWithdraw) returns (bool) {
-        if(_amountToWithdraw != 0 && balances[msg.sender] >= _amountToWithdraw) {
+        if(_amountToWithdraw > 0 && balances[msg.sender] >= _amountToWithdraw) {
             //determine how much you can leave with.
             uint256 reward = _amountToWithdraw * poolBalance/totalSupply; //rounding?
             msg.sender.transfer(reward);


### PR DESCRIPTION
Some major flaws were corrected:

* A buffer overflow on `withdraw` that permited draining the whole contract (no issue opened)
* A rounding problem on `withdraw` which prevented correct payouts (fixes #4)
* Missing update statement for buyer's balance (fixes #3)

Also clearly stated return booleans for correct functioning (and improved readability)